### PR TITLE
Fix vanilla Anvils, Saplings, and Slabs

### DIFF
--- a/src/main/java/mcp/mobius/waila/addons/vanillamc/HUDHandlerVanilla.java
+++ b/src/main/java/mcp/mobius/waila/addons/vanillamc/HUDHandlerVanilla.java
@@ -143,7 +143,10 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
         // the special "smooth" (meta >= 8) versions of double slabs actually look different in a couple cases.
         // so since we can't change the stack, we change the name instead.
         if (block instanceof BlockStoneSlab || block instanceof BlockWoodSlab) {
-            currenttip.set(0, SpecialChars.WHITE + new ItemStack(block, 1, block.damageDropped(accessor.getMetadata())).getDisplayName());
+            currenttip.set(
+                    0,
+                    SpecialChars.WHITE
+                            + new ItemStack(block, 1, block.damageDropped(accessor.getMetadata())).getDisplayName());
         }
 
         return currenttip;

--- a/src/main/java/mcp/mobius/waila/addons/vanillamc/HUDHandlerVanilla.java
+++ b/src/main/java/mcp/mobius/waila/addons/vanillamc/HUDHandlerVanilla.java
@@ -3,6 +3,7 @@ package mcp.mobius.waila.addons.vanillamc;
 import java.util.List;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockAnvil;
 import net.minecraft.block.BlockRedstoneOre;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
@@ -94,6 +95,10 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
 
         if ((block == quartz) && (accessor.getMetadata() > 2)) {
             return new ItemStack(block, 1, 2);
+        }
+
+        if (block instanceof BlockAnvil) {
+            return new ItemStack(block, 1, block.damageDropped(accessor.getMetadata()));
         }
 
         return null;
@@ -245,6 +250,7 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
         ModuleRegistrar.instance().registerStackProvider(provider, log.getClass());
         ModuleRegistrar.instance().registerStackProvider(provider, log2.getClass());
         ModuleRegistrar.instance().registerStackProvider(provider, quartz.getClass());
+        ModuleRegistrar.instance().registerStackProvider(provider, BlockAnvil.class);
 
         // ModuleRegistrar.instance().registerStackProvider(provider, Block.class);
         ModuleRegistrar.instance().registerHeadProvider(provider, mobSpawner.getClass());

--- a/src/main/java/mcp/mobius/waila/addons/vanillamc/HUDHandlerVanilla.java
+++ b/src/main/java/mcp/mobius/waila/addons/vanillamc/HUDHandlerVanilla.java
@@ -45,6 +45,7 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
     static Block log = Blocks.log;
     static Block log2 = Blocks.log2;
     static Block quartz = Blocks.quartz_block;
+    static Block sapling = Blocks.sapling;
 
     @Override
     public ItemStack getWailaStack(IWailaDataAccessor accessor, IWailaConfigHandler config) {
@@ -98,6 +99,10 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
         }
 
         if (block instanceof BlockAnvil) {
+            return new ItemStack(block, 1, block.damageDropped(accessor.getMetadata()));
+        }
+
+        if (block == sapling) {
             return new ItemStack(block, 1, block.damageDropped(accessor.getMetadata()));
         }
 
@@ -251,6 +256,7 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
         ModuleRegistrar.instance().registerStackProvider(provider, log2.getClass());
         ModuleRegistrar.instance().registerStackProvider(provider, quartz.getClass());
         ModuleRegistrar.instance().registerStackProvider(provider, BlockAnvil.class);
+        ModuleRegistrar.instance().registerStackProvider(provider, sapling.getClass());
 
         // ModuleRegistrar.instance().registerStackProvider(provider, Block.class);
         ModuleRegistrar.instance().registerHeadProvider(provider, mobSpawner.getClass());

--- a/src/main/java/mcp/mobius/waila/addons/vanillamc/HUDHandlerVanilla.java
+++ b/src/main/java/mcp/mobius/waila/addons/vanillamc/HUDHandlerVanilla.java
@@ -108,6 +108,10 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
             return new ItemStack(block, 1, block.damageDropped(accessor.getMetadata()));
         }
 
+        if (block instanceof BlockStoneSlab || block instanceof BlockWoodSlab) {
+            return new ItemStack(block, 1, block.damageDropped(accessor.getMetadata()));
+        }
+
         return null;
 
     }
@@ -136,15 +140,6 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
 
         if (block == pumpkinStem) {
             currenttip.set(0, SpecialChars.WHITE + "Pumpkin stem");
-        }
-
-        // the special "smooth" (meta >= 8) versions of double slabs actually look different in a couple cases.
-        // so since we can't change the stack, we change the name instead.
-        if (block instanceof BlockStoneSlab || block instanceof BlockWoodSlab) {
-            currenttip.set(
-                    0,
-                    SpecialChars.WHITE
-                            + new ItemStack(block, 1, block.damageDropped(accessor.getMetadata())).getDisplayName());
         }
 
         return currenttip;
@@ -268,13 +263,13 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
         ModuleRegistrar.instance().registerStackProvider(provider, quartz.getClass());
         ModuleRegistrar.instance().registerStackProvider(provider, anvil.getClass());
         ModuleRegistrar.instance().registerStackProvider(provider, sapling.getClass());
+        ModuleRegistrar.instance().registerStackProvider(provider, BlockStoneSlab.class);
+        ModuleRegistrar.instance().registerStackProvider(provider, BlockWoodSlab.class);
 
         // ModuleRegistrar.instance().registerStackProvider(provider, Block.class);
         ModuleRegistrar.instance().registerHeadProvider(provider, mobSpawner.getClass());
         ModuleRegistrar.instance().registerHeadProvider(provider, melonStem.getClass());
         ModuleRegistrar.instance().registerHeadProvider(provider, pumpkinStem.getClass());
-        ModuleRegistrar.instance().registerHeadProvider(provider, BlockStoneSlab.class);
-        ModuleRegistrar.instance().registerHeadProvider(provider, BlockWoodSlab.class);
 
         ModuleRegistrar.instance().registerBodyProvider(provider, crops.getClass());
         ModuleRegistrar.instance().registerBodyProvider(provider, melonStem.getClass());

--- a/src/main/java/mcp/mobius/waila/addons/vanillamc/HUDHandlerVanilla.java
+++ b/src/main/java/mcp/mobius/waila/addons/vanillamc/HUDHandlerVanilla.java
@@ -100,6 +100,8 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
             return new ItemStack(block, 1, 2);
         }
 
+        // note: this also fixes waila display for modded blocks that extend BlockAnvil.
+        // for example, EnderIO's Dark Steel Anvils and Et Futurum Requiem's Anvil (block replacement).
         if (block instanceof BlockAnvil) {
             return new ItemStack(block, 1, block.damageDropped(accessor.getMetadata()));
         }

--- a/src/main/java/mcp/mobius/waila/addons/vanillamc/HUDHandlerVanilla.java
+++ b/src/main/java/mcp/mobius/waila/addons/vanillamc/HUDHandlerVanilla.java
@@ -3,7 +3,6 @@ package mcp.mobius.waila.addons.vanillamc;
 import java.util.List;
 
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockAnvil;
 import net.minecraft.block.BlockRedstoneOre;
 import net.minecraft.block.BlockStoneSlab;
 import net.minecraft.block.BlockWoodSlab;
@@ -47,6 +46,7 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
     static Block log = Blocks.log;
     static Block log2 = Blocks.log2;
     static Block quartz = Blocks.quartz_block;
+    static Block anvil = Blocks.anvil;
     static Block sapling = Blocks.sapling;
 
     @Override
@@ -100,9 +100,7 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
             return new ItemStack(block, 1, 2);
         }
 
-        // note: this also fixes waila display for modded blocks that extend BlockAnvil.
-        // for example, EnderIO's Dark Steel Anvils and Et Futurum Requiem's Anvil (block replacement).
-        if (block instanceof BlockAnvil) {
+        if (block == anvil) {
             return new ItemStack(block, 1, block.damageDropped(accessor.getMetadata()));
         }
 
@@ -268,7 +266,7 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
         ModuleRegistrar.instance().registerStackProvider(provider, log.getClass());
         ModuleRegistrar.instance().registerStackProvider(provider, log2.getClass());
         ModuleRegistrar.instance().registerStackProvider(provider, quartz.getClass());
-        ModuleRegistrar.instance().registerStackProvider(provider, BlockAnvil.class);
+        ModuleRegistrar.instance().registerStackProvider(provider, anvil.getClass());
         ModuleRegistrar.instance().registerStackProvider(provider, sapling.getClass());
 
         // ModuleRegistrar.instance().registerStackProvider(provider, Block.class);

--- a/src/main/java/mcp/mobius/waila/addons/vanillamc/HUDHandlerVanilla.java
+++ b/src/main/java/mcp/mobius/waila/addons/vanillamc/HUDHandlerVanilla.java
@@ -5,6 +5,8 @@ import java.util.List;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockAnvil;
 import net.minecraft.block.BlockRedstoneOre;
+import net.minecraft.block.BlockStoneSlab;
+import net.minecraft.block.BlockWoodSlab;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -136,6 +138,12 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
             currenttip.set(0, SpecialChars.WHITE + "Pumpkin stem");
         }
 
+        // the special "smooth" (meta >= 8) versions of double slabs actually look different in a couple cases.
+        // so since we can't change the stack, we change the name instead.
+        if (block instanceof BlockStoneSlab || block instanceof BlockWoodSlab) {
+            currenttip.set(0, SpecialChars.WHITE + new ItemStack(block, 1, block.damageDropped(accessor.getMetadata())).getDisplayName());
+        }
+
         return currenttip;
     }
 
@@ -262,6 +270,8 @@ public class HUDHandlerVanilla implements IWailaDataProvider {
         ModuleRegistrar.instance().registerHeadProvider(provider, mobSpawner.getClass());
         ModuleRegistrar.instance().registerHeadProvider(provider, melonStem.getClass());
         ModuleRegistrar.instance().registerHeadProvider(provider, pumpkinStem.getClass());
+        ModuleRegistrar.instance().registerHeadProvider(provider, BlockStoneSlab.class);
+        ModuleRegistrar.instance().registerHeadProvider(provider, BlockWoodSlab.class);
 
         ModuleRegistrar.instance().registerBodyProvider(provider, crops.getClass());
         ModuleRegistrar.instance().registerBodyProvider(provider, melonStem.getClass());


### PR DESCRIPTION
Vanilla anvils, saplings, and slabs all displayed incorrectly in WAILA in certain situations. Their block forms all use extra metadata than their item forms and WAILA didn't account for this.
<details>  

## Anvils
Anvil items and blocks use different metadata. 

| Item Meta | Represents |
| --- | --- |
| 0 | Anvil |
| 1 | Slightly Damaged Anvil |
| 2 | Very Damaged Anvil |

| Block Meta | Represents |
| --- | --- |
| 0/1/2/3 | Anvil, facing 4 directions |
| 4/5/6/7 | Slightly Damaged Anvil, facing 4 directions |
| 8/9/10/11 | Very Damaged Anvil, facing 4 directions |

Undamaged Anvils facing in certain directions would display in WAILA as Slightly Damaged or Very Damaged. Every other meta would display as an undamaged Anvil. 

## Saplings
In case you didn't know, vanilla saplings have two growth stages, stage 0 and stage 1. When you first place a sapling, it's in growth stage 0. Letting it tick or applying bone meal advances it to stage 1. Letting it tick or applying bone meal once more will cause it to grow into a tree. 
Sapling blocks use the top bit to determine if they're in stage 1 or not. Sapling items don't use this meta, so all growth stage 1 saplings would display in WAILA with the name "Oak Sapling" no matter what sapling they are. 

## Slabs
Single slab blocks use the top bit to determine if they're top slabs or bottom slabs. Single slab items don't use this meta, so all top slabs would display in WAILA with the slab name for meta 0. For example, Quartz top slabs would display as "Stone Slab" and Acacia top slabs would display as "Oak Slab".

</details>