### PR TITLE
Add signal strength indicator for ProjectRed wires

### DIFF
--- a/src/main/java/mcp/mobius/waila/addons/projectred/HUDFMPWires.java
+++ b/src/main/java/mcp/mobius/waila/addons/projectred/HUDFMPWires.java
@@ -1,0 +1,41 @@
+package mcp.mobius.waila.addons.projectred;
+
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+
+import mcp.mobius.waila.api.ITaggedList;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaFMPAccessor;
+import mcp.mobius.waila.api.IWailaFMPProvider;
+import mcp.mobius.waila.cbcore.LangUtil;
+import mcp.mobius.waila.utils.NBTUtil;
+
+public class HUDFMPWires implements IWailaFMPProvider {
+
+    @Override
+    public List<String> getWailaHead(ItemStack itemStack, List<String> currenttip, IWailaFMPAccessor accessor,
+            IWailaConfigHandler config) {
+        return currenttip;
+    }
+
+    @Override
+    public List<String> getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaFMPAccessor accessor,
+            IWailaConfigHandler config) {
+        if (!config.getConfig("pr.showsignal")) return currenttip;
+
+        ITaggedList<String, String> tagList = (ITaggedList<String, String>) currenttip;
+        int signal = ((NBTUtil.getNBTInteger(accessor.getNBTData(), "signal") & 0xff) + 16) / 17;
+        if (tagList.getEntries("signal").isEmpty()) {
+            tagList.add(String.format("%s : %s", LangUtil.translateG("hud.msg.power"), signal), "signal");
+        }
+
+        return currenttip;
+    }
+
+    @Override
+    public List<String> getWailaTail(ItemStack itemStack, List<String> currenttip, IWailaFMPAccessor accessor,
+            IWailaConfigHandler config) {
+        return currenttip;
+    }
+}

--- a/src/main/java/mcp/mobius/waila/addons/projectred/ProjectRedModule.java
+++ b/src/main/java/mcp/mobius/waila/addons/projectred/ProjectRedModule.java
@@ -18,6 +18,7 @@ public class ProjectRedModule {
 
         ModuleRegistrar.instance().addConfigRemote("Project:Red", "pr.showio");
         ModuleRegistrar.instance().addConfigRemote("Project:Red", "pr.showdata");
+        ModuleRegistrar.instance().addConfigRemote("Project:Red", "pr.showsignal");
 
         ModuleRegistrar.instance().registerBodyProvider(new HUDFMPGateLogic(), "pr_sgate");
         ModuleRegistrar.instance().registerBodyProvider(new HUDFMPGateLogic(), "pr_igate");
@@ -25,6 +26,10 @@ public class ProjectRedModule {
         ModuleRegistrar.instance().registerBodyProvider(new HUDFMPGateLogic(), "pr_bgate");
         ModuleRegistrar.instance().registerBodyProvider(new HUDFMPGateLogic(), "pr_agate");
         ModuleRegistrar.instance().registerBodyProvider(new HUDFMPGateLogic(), "pr_rgate");
+        ModuleRegistrar.instance().registerBodyProvider(new HUDFMPWires(), "pr_redwire");
+        ModuleRegistrar.instance().registerBodyProvider(new HUDFMPWires(), "pr_insulated");
+        ModuleRegistrar.instance().registerBodyProvider(new HUDFMPWires(), "pr_fredwire");
+        ModuleRegistrar.instance().registerBodyProvider(new HUDFMPWires(), "pr_finsulated");
 
         ModuleRegistrar.instance().registerDecorator(new HUDDecoratorRsGateLogic(), "pr_sgate");
         ModuleRegistrar.instance().registerDecorator(new HUDDecoratorRsGateLogic(), "pr_igate");

--- a/src/main/resources/assets/waila/lang/en_US.lang
+++ b/src/main/resources/assets/waila/lang/en_US.lang
@@ -135,6 +135,7 @@ option.bcapi.consump=Show maximum power
 option.bcapi.trigger=Show triggering energy
 option.pr.showio=Show gates IO
 option.pr.showdata=Show gates data
+option.pr.showsignal=Show wire signal strength
 option.extrautilities.fluidamount=Show fluid amount
 option.openblocks.fluidamount=Show fluid amount
 option.railcraft.fluidamount=Show fluid amount


### PR DESCRIPTION
It's practically impossible to tell the difference between low power and unpowered wires atm but hopefully this can solve that.

Just for note I'm doing the tagged list stuff to prevent this nonsense
![waila_wire](https://github.com/GTNewHorizons/waila/assets/127234178/ee9e0cd5-57a0-486a-8028-b664e64e691d)
And a simple List.contains won't suffice since this is apparently a thing
![waila_wire2](https://github.com/GTNewHorizons/waila/assets/127234178/3ee4b31a-5432-40be-9808-ecc5b1a63ebd)