### PR TITLE
Use the right event to render the HUD to benefit from HUD Caching

### DIFF
--- a/src/main/java/mcp/mobius/waila/Waila.java
+++ b/src/main/java/mcp/mobius/waila/Waila.java
@@ -80,7 +80,7 @@ public class Waila {
             MinecraftForge.EVENT_BUS.register(new DecoratorRenderer());
             FMLCommonHandler.instance().bus().register(new KeyEvent());
             FMLCommonHandler.instance().bus().register(WailaTickHandler.instance());
-
+            MinecraftForge.EVENT_BUS.register(WailaTickHandler.instance());
         }
         FMLCommonHandler.instance().bus().register(new NetworkHandler());
     }

--- a/src/main/java/mcp/mobius/waila/overlay/WailaTickHandler.java
+++ b/src/main/java/mcp/mobius/waila/overlay/WailaTickHandler.java
@@ -10,6 +10,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.common.config.Configuration;
 
 import org.lwjgl.input.Keyboard;
@@ -43,7 +44,7 @@ public class WailaTickHandler {
 
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
-    public void tickRender(TickEvent.RenderTickEvent event) {
+    public void tickRender(RenderGameOverlayEvent.Text event) {
         OverlayRenderer.renderOverlay();
     }
 


### PR DESCRIPTION
Currently it is using the `TickEvent.RenderTickEvent` to render the HUD, first of all waila is not checking for event phase.START or END which means that currently it is rendering the HUD twice per frame. Moreover using this event doesn't benefit from HUD caching.

So I changed it to use the RenderGameOverlay Event to benefit from HUD caching