### PR TITLE
Add a total size counter to thaumcraft nodes

### DIFF
--- a/src/main/java/mcp/mobius/waila/addons/thaumcraft/HUDHandlerIAspectContainer.java
+++ b/src/main/java/mcp/mobius/waila/addons/thaumcraft/HUDHandlerIAspectContainer.java
@@ -1,6 +1,7 @@
 package mcp.mobius.waila.addons.thaumcraft;
 
 import static mcp.mobius.waila.api.SpecialChars.ALIGNRIGHT;
+import static mcp.mobius.waila.api.SpecialChars.AQUA;
 import static mcp.mobius.waila.api.SpecialChars.TAB;
 import static mcp.mobius.waila.api.SpecialChars.WHITE;
 
@@ -19,6 +20,8 @@ import net.minecraft.world.World;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import mcp.mobius.waila.api.IWailaDataProvider;
+import mcp.mobius.waila.cbcore.LangUtil;
+import thaumcraft.api.nodes.INode;
 
 public class HUDHandlerIAspectContainer implements IWailaDataProvider {
 
@@ -45,15 +48,28 @@ public class HUDHandlerIAspectContainer implements IWailaDataProvider {
 
             List<String> unknownAspects = new ArrayList<>();
 
+            int total = 0;
+
             for (int i = 0; i < taglist.tagCount(); i++) {
                 NBTTagCompound subtag = taglist.getCompoundTagAt(i);
 
                 String aspect = subtag.getString("key");
-                String amount = String.valueOf(subtag.getInteger("value"));
+                int value = subtag.getInteger("value");
+                total += value;
+                String amount = String.valueOf(value);
 
                 if (!aspect.equals("???"))
                     currenttip.add(String.format("%s" + TAB + ALIGNRIGHT + WHITE + "%s", aspect, amount));
                 else unknownAspects.add(String.format("%s" + TAB + ALIGNRIGHT + WHITE + "%s", aspect, amount));
+            }
+
+            if (accessor.getTileEntity() instanceof INode && (taglist.tagCount() > 10 || total > 300)) {
+                currenttip.add(
+                        0,
+                        String.format(
+                                AQUA + "%s" + TAB + ALIGNRIGHT + WHITE + "%s",
+                                LangUtil.translateG("hud.msg.tcnodetotalsize"),
+                                total));
             }
 
             currenttip.addAll(unknownAspects);

--- a/src/main/resources/assets/waila/lang/en_US.lang
+++ b/src/main/resources/assets/waila/lang/en_US.lang
@@ -95,6 +95,8 @@ hud.msg.record=Record
 hud.msg.offers=Offers
 hud.msg.demands=Demands
 
+hud.msg.tcnodetotalsize=Total Size
+
 option.appeng.monitorcontent=Monitor's content
 option.bb.content=Barrel's content
 option.bc.tankamount=Liquid amount


### PR DESCRIPTION
This will add a line to the top of the nei tooltip for thaumcraft nodes with a sum of all aspects the node has
It's pretty much only useful when deliberately creating large nodes so it'll only apply to nodes with more than 10 aspects or where the sum of all aspects is greater than 300

![image](https://github.com/user-attachments/assets/75a101ee-7f40-4a61-85fa-8b77cc83c4dc)