### PR TITLE
Fix thaumcraft node aspects overflowing out of the tooltip bounding box

### DIFF
--- a/src/main/java/mcp/mobius/waila/overlay/Tooltip.java
+++ b/src/main/java/mcp/mobius/waila/overlay/Tooltip.java
@@ -134,9 +134,20 @@ public class Tooltip {
         // We correct if we only have one column
         if (columnsWidth.size() == 1) columnsWidth.set(0, maxStringW);
 
-        // We compute the position of the columns to be able to align the renderable later on
-        for (int i = 1; i < columnsWidth.size(); i++)
-            columnsPos.set(i, columnsWidth.get(i - 1) + columnsPos.get(i - 1) + TabSpacing);
+        int tmp = 0;
+
+        for (int i = 0; i < columnsWidth.size(); i++) {
+            tmp += columnsWidth.get(i);
+
+            // We compute the position of the columns to be able to align the renderable later on
+            if (i != 0) {
+                columnsPos.set(i, columnsWidth.get(i - 1) + columnsPos.get(i - 1) + TabSpacing);
+            }
+        }
+
+        // We correct for edge cases where the longest string in a column is in a line shorter than the longest line
+        tmp += TabSpacing * (columnsWidth.size() - 1);
+        maxStringW = Math.max(maxStringW, tmp);
 
         this.computeRenderables();
         this.computePositionAndSize(hasIcon);


### PR DESCRIPTION
Right now waila only takes into account the length of the longest individual line when determining the size of the tooltip, without accounting for cases where the length of the line is increased by the columns feature it has, this patch will fix that

This code runs for every frame when a waila tooltip is visible, so please you review it carefully in case I missed something. Also, since every single waila addon relies on this class I think it should probably be play tested for a little while before being merged into a release
It's also definitely possible to fix the overflowing by working around this bug in the thaumcraft addon, but that would make it less readable and look worse, so I'll leave that to the maintainers 

before
![image](https://github.com/user-attachments/assets/9514d970-b393-4ef3-89e1-5fab47dab4f9)

after
![image](https://github.com/user-attachments/assets/8270def1-5b8a-4430-b9c8-4e6ee804928a)


