### PR TITLE
Stop running tick events twice per tick

### DIFF
--- a/src/main/java/mcp/mobius/waila/overlay/WailaTickHandler.java
+++ b/src/main/java/mcp/mobius/waila/overlay/WailaTickHandler.java
@@ -44,7 +44,9 @@ public class WailaTickHandler {
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
     public void tickRender(TickEvent.RenderTickEvent event) {
-        OverlayRenderer.renderOverlay();
+        if (event.phase == TickEvent.Phase.END) {
+            OverlayRenderer.renderOverlay();
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/mcp/mobius/waila/overlay/WailaTickHandler.java
+++ b/src/main/java/mcp/mobius/waila/overlay/WailaTickHandler.java
@@ -53,6 +53,8 @@ public class WailaTickHandler {
     @SideOnly(Side.CLIENT)
     public void tickClient(TickEvent.ClientTickEvent event) {
 
+        if (event.phase == TickEvent.Phase.START) return;
+
         if (!Keyboard.isKeyDown(KeyEvent.key_show.getKeyCode())
                 && !ConfigHandler.instance().getConfig(Configuration.CATEGORY_GENERAL, Constants.CFG_WAILA_MODE, false)
                 && ConfigHandler.instance()


### PR DESCRIPTION
It is currently rendering the HUD twice per frame as well as running the logic twice per tick.