### PR TITLE
feat(api): Add support for advanced tooltip body

### DIFF
--- a/src/main/java/mcp/mobius/waila/api/IWailaDataProvider.java
+++ b/src/main/java/mcp/mobius/waila/api/IWailaDataProvider.java
@@ -63,6 +63,35 @@ public interface IWailaDataProvider {
             IWailaConfigHandler config);
 
     /**
+     * Callback used to determine if there is extended information to display for the Body section. If this returns
+     * true, Waila will either display the "Hold <KEY> for more info" prompt or call getWailaAdvancedBody if the key is
+     * being held.
+     *
+     * @param itemStack Current block scanned, in ItemStack form.
+     * @param accessor  Contains most of the relevant information about the current environment.
+     * @param config    Current configuration of Waila.
+     * @return True if advanced body information is available, false otherwise.
+     */
+    default boolean hasAdvancedBody(ItemStack itemStack, IWailaDataAccessor accessor, IWailaConfigHandler config) {
+        return false; // Default to false for backward compatibility
+    }
+
+    /**
+     * Callback used to add the extended lines to the Body section of the tooltip. This method is ONLY called if
+     * hasAdvancedBody returns true AND the player is holding the configured key for advanced tooltips.
+     *
+     * @param itemStack  Current block scanned, in ItemStack form.
+     * @param currenttip The current list of tooltip lines, including the normal body.
+     * @param accessor   Contains most of the relevant information about the current environment.
+     * @param config     Current configuration of Waila.
+     * @return Modified input currenttip with advanced information appended.
+     */
+    default List<String> getWailaAdvancedBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
+            IWailaConfigHandler config) {
+        return currenttip; // Default to returning the unmodified list
+    }
+
+    /**
      * Callback used to add lines to one of the three sections of the tooltip (Head, Body, Tail).</br>
      * Will be used if the implementing class is registered via {@link IWailaRegistrar}.{@link registerTailProvider}
      * client side.</br>

--- a/src/main/java/mcp/mobius/waila/client/KeyEvent.java
+++ b/src/main/java/mcp/mobius/waila/client/KeyEvent.java
@@ -23,6 +23,7 @@ public class KeyEvent {
     public static KeyBinding key_liquid;
     public static KeyBinding key_recipe;
     public static KeyBinding key_usage;
+    public static KeyBinding key_show_advanced;
 
     public KeyEvent() {
         ClientRegistry
@@ -35,6 +36,8 @@ public class KeyEvent {
                 key_recipe = new KeyBinding(Constants.BIND_WAILA_RECIPE, Keyboard.KEY_NUMPAD3, "Waila"));
         ClientRegistry.registerKeyBinding(
                 key_usage = new KeyBinding(Constants.BIND_WAILA_USAGE, Keyboard.KEY_NUMPAD4, "Waila"));
+        ClientRegistry.registerKeyBinding(
+                key_show_advanced = new KeyBinding(Constants.BIND_WAILA_SHOW_ADVANCED, Keyboard.KEY_LSHIFT, "Waila"));
     }
 
     @SubscribeEvent

--- a/src/main/java/mcp/mobius/waila/utils/Constants.java
+++ b/src/main/java/mcp/mobius/waila/utils/Constants.java
@@ -6,6 +6,7 @@ public final class Constants {
 
     public static String BIND_WAILA_CFG = "waila.keybind.wailaconfig";
     public static String BIND_WAILA_SHOW = "waila.keybind.wailadisplay";
+    public static String BIND_WAILA_SHOW_ADVANCED = "waila.keybind.showadvanced";
     public static String BIND_WAILA_LIQUID = "waila.keybind.liquid";
     public static String BIND_WAILA_RECIPE = "waila.keybind.recipe";
     public static String BIND_WAILA_USAGE = "waila.keybind.usage";

--- a/src/main/resources/assets/waila/lang/cs_CZ.lang
+++ b/src/main/resources/assets/waila/lang/cs_CZ.lang
@@ -30,6 +30,7 @@ enchant.label.enchantability=Oèarovatelnost
 
 waila.keybind.wailaconfig=[Waila] Nastavení obrazu
 waila.keybind.wailadisplay=[Waila] Zobrazit/Skrýt
+waila.keybind.showadvanced=[Waila] Rozšířit popisek
 waila.keybind.liquid=[Waila] Zobrazit tekutiny
 waila.keybind.recipe=[Waila] Zobrazit recept
 waila.keybind.usage=[Waila] Zobrazit použití
@@ -37,6 +38,8 @@ waila.keybind.testing=[Waila] Testování
 
 client.msg.norecipe=Nenalezen žádný recept.
 client.msg.nousage=Nenalezeno žádné využití.
+
+hud.msg.holdkeymoreinfo=Držte %s pro více informací
 
 hud.msg.none=<Nic>
 hud.msg.empty=<Prázdný>

--- a/src/main/resources/assets/waila/lang/de_DE.lang
+++ b/src/main/resources/assets/waila/lang/de_DE.lang
@@ -30,6 +30,7 @@ enchant.label.enchantability=Verzauberbarkeit
 
 waila.keybind.wailaconfig=[Waila] Config-Bildschirm
 waila.keybind.wailadisplay=[Waila] Zeigen/Verstecken
+waila.keybind.showadvanced=[Waila] Tooltip erweitern
 waila.keybind.liquid=[Waila] Zeige Flüssigkeiten
 waila.keybind.recipe=[Waila] Zeige Rezept
 waila.keybind.usage=[Waila] Zeige Nutzung
@@ -37,6 +38,8 @@ waila.keybind.testing=[Waila] Testen
 
 client.msg.norecipe=Kein Rezept gefunden.
 client.msg.nousage=Keine Nutzung gefunden.
+
+hud.msg.holdkeymoreinfo=Halte %s für mehr Infos
 
 hud.msg.none=<Nichts>
 hud.msg.empty=<Leer>

--- a/src/main/resources/assets/waila/lang/en_US.lang
+++ b/src/main/resources/assets/waila/lang/en_US.lang
@@ -31,6 +31,7 @@ enchant.label.enchantability=Enchantability
 
 waila.keybind.wailaconfig=[Waila] Config screen
 waila.keybind.wailadisplay=[Waila] Show/Hide
+waila.keybind.showadvanced=[Waila] Expand Tooltip
 waila.keybind.liquid=[Waila] Show liquids
 waila.keybind.recipe=[Waila] Show recipe
 waila.keybind.usage=[Waila] Show usage
@@ -38,6 +39,8 @@ waila.keybind.testing=[Waila] Testing
 
 client.msg.norecipe=No recipe found.
 client.msg.nousage=No usage found.
+
+hud.msg.holdkeymoreinfo=Hold %s for more info
 
 hud.msg.none=<None>
 hud.msg.empty=<Empty>

--- a/src/main/resources/assets/waila/lang/et_EE.lang
+++ b/src/main/resources/assets/waila/lang/et_EE.lang
@@ -30,6 +30,7 @@ enchant.label.enchantability=Loitsitav
 
 waila.keybind.wailaconfig=[Waila] Konfiguratsiooni ekraan
 waila.keybind.wailadisplay=[Waila] Näita/Peida
+waila.keybind.showadvanced=[Waila] Laienda kohtspikrit
 waila.keybind.liquid=[Waila] Näita vedelikke
 waila.keybind.recipe=[Waila] Näita retsepti
 waila.keybind.usage=[Waila] Näita kasutamist
@@ -37,6 +38,8 @@ waila.keybind.testing=[Waila] Testimine
 
 client.msg.norecipe=Ühtegi retsepti ei leitud.
 client.msg.nousage=Ühtegi kasutust ei leitud.
+
+hud.msg.holdkeymoreinfo=Hoia %s lisainfo saamiseks
 
 hud.msg.none=<Mitte Ükski>
 hud.msg.empty=<Tühi>

--- a/src/main/resources/assets/waila/lang/fr_FR.lang
+++ b/src/main/resources/assets/waila/lang/fr_FR.lang
@@ -28,6 +28,7 @@ enchant.label.enchantability=Enchantabilitée
 
 waila.keybind.wailaconfig=[Waila] Ecran de config
 waila.keybind.wailadisplay=[Waila] Afficher/Masquer
+waila.keybind.showadvanced=[Waila] Développer l'info-bulle
 waila.keybind.liquid=[Waila] Afficher les liquides
 waila.keybind.recipe=[Waila] Afficher les recettes
 waila.keybind.usage=[Waila] Afficher l'utilisation
@@ -35,6 +36,8 @@ waila.keybind.testing=[Waila] Test
 
 client.msg.norecipe=Pas de recette trouvée.
 client.msg.nousage=Pas d'utilisation trouvée.
+
+hud.msg.holdkeymoreinfo=Maintenez %s pour plus d'infos
 
 hud.msg.none=<Aucun>
 hud.msg.empty=<Vide>

--- a/src/main/resources/assets/waila/lang/it_IT.lang
+++ b/src/main/resources/assets/waila/lang/it_IT.lang
@@ -30,6 +30,7 @@ enchant.label.enchantability=Incantabilità
 
 waila.keybind.wailaconfig=[Waila] Config menù
 waila.keybind.wailadisplay=[Waila] Mostra/Nascondi
+waila.keybind.showadvanced=[Waila] Espandi tooltip
 waila.keybind.liquid=[Waila] Mostra liquidi
 waila.keybind.recipe=[Waila] Mostra ricetta
 waila.keybind.usage=[Waila] Mostra uso
@@ -37,6 +38,8 @@ waila.keybind.testing=[Waila] Provare
 
 client.msg.norecipe=Nessuna ricetta trovata.
 client.msg.nousage=Nessun uso trovato.
+
+hud.msg.holdkeymoreinfo=Tieni premuto %s per più info
 
 hud.msg.none=<Niente>
 hud.msg.empty=<Vuoto>

--- a/src/main/resources/assets/waila/lang/nl_NL.lang
+++ b/src/main/resources/assets/waila/lang/nl_NL.lang
@@ -28,6 +28,7 @@ enchant.label.enchantability=Enchantbaarheid
 
 waila.keybind.wailaconfig=[Waila] Configuratiescherm
 waila.keybind.wailadisplay=[Waila] Toon/Verberg
+waila.keybind.showadvanced=[Waila] Tooltip uitvouwen
 waila.keybind.liquid=[Waila] Toon vloeistoffen
 waila.keybind.recipe=[Waila] Toon recepten
 waila.keybind.usage=[Waila] Toon gebruik
@@ -35,6 +36,8 @@ waila.keybind.testing=[Waila] Testen
 
 client.msg.norecipe=Geen recept gevonden.
 client.msg.nousage=Geen gebruik gevonden.
+
+hud.msg.holdkeymoreinfo=Houd %s ingedrukt voor meer info
 
 hud.msg.none=<Geen>
 hud.msg.empty=<Leeg>

--- a/src/main/resources/assets/waila/lang/ru_RU.lang
+++ b/src/main/resources/assets/waila/lang/ru_RU.lang
@@ -30,6 +30,7 @@ enchant.label.enchantability=Зачарование
 
 waila.keybind.wailaconfig=[Waila] Меню настроек
 waila.keybind.wailadisplay=[Waila] Показать/Скрыть
+waila.keybind.showadvanced=[Waila] Развернуть подсказку
 waila.keybind.liquid=[Waila] Показать жидкости
 waila.keybind.recipe=[Waila] Показать рецепт
 waila.keybind.usage=[Waila] Показать применение
@@ -37,6 +38,8 @@ waila.keybind.testing=[Waila] Тестировать
 
 client.msg.norecipe=Рецептов не найдено.
 client.msg.nousage=Применений не найдено.
+
+hud.msg.holdkeymoreinfo=Удерживайте %s для подробностей
 
 hud.msg.none=<Ничего>
 hud.msg.empty=<Пусто>

--- a/src/main/resources/assets/waila/lang/zh_CN.lang
+++ b/src/main/resources/assets/waila/lang/zh_CN.lang
@@ -30,6 +30,7 @@ enchant.label.enchantability=附魔能力
 
 waila.keybind.wailaconfig=[Waila]配置屏幕
 waila.keybind.wailadisplay=[Waila]显示/隐藏
+waila.keybind.showadvanced=[Waila]展开工具提示
 waila.keybind.liquid=[Waila]显示流体
 waila.keybind.recipe=[Waila]显示合成
 waila.keybind.usage=[Waila]显示可参与合成
@@ -37,6 +38,8 @@ waila.keybind.testing=[Waila]测试中
 
 client.msg.norecipe=未发现合成表.
 client.msg.nousage=未发现可参与合成.
+
+hud.msg.holdkeymoreinfo=按住 %s 查看更多信息
 
 hud.msg.none=<无>
 hud.msg.empty=<空>


### PR DESCRIPTION
This is the first step into being able to resolve https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18491, once this is accepted I can work into adapting the WailaDataProviders in GT and others mods

Adds two new default methods to the `IWailaDataProvider` interface:
- `hasAdvancedBody()`: Checks if advanced info is available.
- `getWailaAdvancedBody()`: Provides the advanced info strings.

This allows mods to stop reimplementing the same logic of "Hold Shift for more info" in their own way, and allow players to customize the key.

**Because the new methods are default, this is a non-breaking change**


Note: Translations done automatically, I can only vouch for en_US and fr_FR