### PR TITLE
Prevent overflowing of bars in tooltip renderers

### DIFF
--- a/src/main/java/mcp/mobius/waila/overlay/tooltiprenderers/TTRenderFluidBar.java
+++ b/src/main/java/mcp/mobius/waila/overlay/tooltiprenderers/TTRenderFluidBar.java
@@ -53,10 +53,11 @@ public class TTRenderFluidBar implements IWailaVariableWidthTooltipRenderer {
     @Override
     public Dimension getSize(String[] params, IWailaCommonAccessor accessor) {
         boolean isEmpty = (params[0].equals("EMPTYFLUID") && params[1].equals("EMPTYFLUID"));
+        double amount = Double.parseDouble(params[2]);
         int displayWidth = DisplayUtil.getDisplayWidth(
                 buildDisplayText(
-                        isEmpty ? 0 : Double.parseDouble(params[2]),
-                        Double.parseDouble(params[3]),
+                        isEmpty ? 0 : amount,
+                        Math.max(Double.parseDouble(params[3]), amount),
                         params[1],
                         isEmpty));
 
@@ -70,7 +71,7 @@ public class TTRenderFluidBar implements IWailaVariableWidthTooltipRenderer {
         String fluidName = params[0];
         String localizedName = params[1];
         double amount = Double.parseDouble(params[2]);
-        double capacity = Double.parseDouble(params[3]);
+        double capacity = Math.max(Double.parseDouble(params[3]), amount);
         Tessellator tessellator = Tessellator.instance;
         boolean isEmpty = fluidName.equals("EMPTYFLUID") && localizedName.equals("EMPTYFLUID");
 

--- a/src/main/java/mcp/mobius/waila/overlay/tooltiprenderers/TTRenderFluidBar.java
+++ b/src/main/java/mcp/mobius/waila/overlay/tooltiprenderers/TTRenderFluidBar.java
@@ -53,11 +53,10 @@ public class TTRenderFluidBar implements IWailaVariableWidthTooltipRenderer {
     @Override
     public Dimension getSize(String[] params, IWailaCommonAccessor accessor) {
         boolean isEmpty = (params[0].equals("EMPTYFLUID") && params[1].equals("EMPTYFLUID"));
-        double amount = Double.parseDouble(params[2]);
         int displayWidth = DisplayUtil.getDisplayWidth(
                 buildDisplayText(
-                        isEmpty ? 0 : amount,
-                        Math.max(Double.parseDouble(params[3]), amount),
+                        isEmpty ? 0 : Double.parseDouble(params[2]),
+                        Double.parseDouble(params[3]),
                         params[1],
                         isEmpty));
 
@@ -71,7 +70,7 @@ public class TTRenderFluidBar implements IWailaVariableWidthTooltipRenderer {
         String fluidName = params[0];
         String localizedName = params[1];
         double amount = Double.parseDouble(params[2]);
-        double capacity = Math.max(Double.parseDouble(params[3]), amount);
+        double capacity = Double.parseDouble(params[3]);
         Tessellator tessellator = Tessellator.instance;
         boolean isEmpty = fluidName.equals("EMPTYFLUID") && localizedName.equals("EMPTYFLUID");
 
@@ -84,7 +83,7 @@ public class TTRenderFluidBar implements IWailaVariableWidthTooltipRenderer {
             tessellator.startDrawingQuads();
             // Intentionally draw 2 pixels taller than needed than cover with the border to make the texture more
             // visible
-            int i = (int) ((double) (maxStringW - 2) * amount / capacity);
+            int i = (int) ((double) (maxStringW - 2) * (amount / Math.max(capacity, amount)));
             int j = 0;
             for (; i > height; i = i - height) {
                 drawRectFromIcon(tessellator, 1 + (j * height), 0, 0, icon, height, height);

--- a/src/main/java/mcp/mobius/waila/overlay/tooltiprenderers/TTRenderProgressBar.java
+++ b/src/main/java/mcp/mobius/waila/overlay/tooltiprenderers/TTRenderProgressBar.java
@@ -22,7 +22,7 @@ public class TTRenderProgressBar implements IWailaTooltipRenderer {
     @Override
     public void draw(String[] params, IWailaCommonAccessor accessor) {
         int currentValue = Integer.parseInt(params[0]);
-        int maxValue = Math.max(Integer.parseInt(params[1]), currentValue);
+        int maxValue = Integer.parseInt(params[1]);
 
         int progress = (currentValue * 28) / maxValue;
 

--- a/src/main/java/mcp/mobius/waila/overlay/tooltiprenderers/TTRenderProgressBar.java
+++ b/src/main/java/mcp/mobius/waila/overlay/tooltiprenderers/TTRenderProgressBar.java
@@ -22,7 +22,7 @@ public class TTRenderProgressBar implements IWailaTooltipRenderer {
     @Override
     public void draw(String[] params, IWailaCommonAccessor accessor) {
         int currentValue = Integer.parseInt(params[0]);
-        int maxValue = Integer.parseInt(params[1]);
+        int maxValue = Math.max(Integer.parseInt(params[1]), currentValue);
 
         int progress = (currentValue * 28) / maxValue;
 

--- a/src/main/java/mcp/mobius/waila/overlay/tooltiprenderers/TTRenderRFBar.java
+++ b/src/main/java/mcp/mobius/waila/overlay/tooltiprenderers/TTRenderRFBar.java
@@ -24,9 +24,8 @@ public class TTRenderRFBar implements IWailaVariableWidthTooltipRenderer {
 
     @Override
     public Dimension getSize(String[] params, IWailaCommonAccessor accessor) {
-        int amount = Integer.parseInt(params[0]);
         return new Dimension(
-                DisplayUtil.getDisplayWidth(buildDisplayText(amount, Math.max(Integer.parseInt(params[1]), amount)))
+                DisplayUtil.getDisplayWidth(buildDisplayText(Integer.parseInt(params[0]),Integer.parseInt(params[1])))
                         + 4,
                 height);
     }
@@ -37,7 +36,7 @@ public class TTRenderRFBar implements IWailaVariableWidthTooltipRenderer {
     @Override
     public void draw(String[] params, IWailaCommonAccessor accessor) {
         int amount = Integer.parseInt(params[0]);
-        int capacity = Math.max(Integer.parseInt(params[1]), amount);
+        int capacity = Integer.parseInt(params[1]);
         Tessellator tessellator = Tessellator.instance;
 
         Minecraft mc = Minecraft.getMinecraft();
@@ -51,7 +50,7 @@ public class TTRenderRFBar implements IWailaVariableWidthTooltipRenderer {
             drawRect(tessellator, 1 + i, 0, 0, width, height, 0.0, 0.0, 0.5, 1.0);
         }
 
-        double i = (double) (maxStringW - 2) * amount / capacity;
+        double i = (double) (maxStringW - 2) * ((double) amount / Math.max(capacity, amount));
         int drawnRects = 0;
         for (; i > width; i -= width) {
             drawRect(tessellator, 1 + (drawnRects * width), 0, 0, width, height, 0.5, 0.0, 1.0, 1.0);

--- a/src/main/java/mcp/mobius/waila/overlay/tooltiprenderers/TTRenderRFBar.java
+++ b/src/main/java/mcp/mobius/waila/overlay/tooltiprenderers/TTRenderRFBar.java
@@ -24,8 +24,9 @@ public class TTRenderRFBar implements IWailaVariableWidthTooltipRenderer {
 
     @Override
     public Dimension getSize(String[] params, IWailaCommonAccessor accessor) {
+        int amount = Integer.parseInt(params[0]);
         return new Dimension(
-                DisplayUtil.getDisplayWidth(buildDisplayText(Integer.parseInt(params[0]), Integer.parseInt(params[1])))
+                DisplayUtil.getDisplayWidth(buildDisplayText(amount, Math.max(Integer.parseInt(params[1]), amount)))
                         + 4,
                 height);
     }
@@ -36,7 +37,7 @@ public class TTRenderRFBar implements IWailaVariableWidthTooltipRenderer {
     @Override
     public void draw(String[] params, IWailaCommonAccessor accessor) {
         int amount = Integer.parseInt(params[0]);
-        int capacity = Integer.parseInt(params[1]);
+        int capacity = Math.max(Integer.parseInt(params[1]), amount);
         Tessellator tessellator = Tessellator.instance;
 
         Minecraft mc = Minecraft.getMinecraft();

--- a/src/main/java/mcp/mobius/waila/overlay/tooltiprenderers/TTRenderRFBar.java
+++ b/src/main/java/mcp/mobius/waila/overlay/tooltiprenderers/TTRenderRFBar.java
@@ -25,7 +25,7 @@ public class TTRenderRFBar implements IWailaVariableWidthTooltipRenderer {
     @Override
     public Dimension getSize(String[] params, IWailaCommonAccessor accessor) {
         return new Dimension(
-                DisplayUtil.getDisplayWidth(buildDisplayText(Integer.parseInt(params[0]),Integer.parseInt(params[1])))
+                DisplayUtil.getDisplayWidth(buildDisplayText(Integer.parseInt(params[0]), Integer.parseInt(params[1])))
                         + 4,
                 height);
     }


### PR DESCRIPTION
Prevents bars going out of the waila bounds, if for some weird reason the amount is bigger than the capacity, such as this case: https://discord.com/channels/181078474394566657/522098956491030558/1502992908045778976 - image for that:

<img width="1210" height="184" alt="image" src="https://github.com/user-attachments/assets/aeac95f5-9815-4655-b33f-4ec075ea8816" />
