### PR TITLE
Allow Waila to handle bigger NBT packet

### DIFF
--- a/src/main/java/mcp/mobius/waila/network/WailaPacketHandler.java
+++ b/src/main/java/mcp/mobius/waila/network/WailaPacketHandler.java
@@ -90,20 +90,20 @@ public enum WailaPacketHandler {
     }
 
     public void writeNBT(ByteBuf target, NBTTagCompound tag) throws IOException {
-        if (tag == null) target.writeShort(-1);
+        if (tag == null) target.writeInt(-1);
         else {
             byte[] abyte = CompressedStreamTools.compress(tag);
-            target.writeShort((short) abyte.length);
+            target.writeInt(abyte.length);
             target.writeBytes(abyte);
         }
     }
 
     public NBTTagCompound readNBT(ByteBuf dat) throws IOException {
-        short short1 = dat.readShort();
+        int val = dat.readInt();
 
-        if (short1 < 0) return null;
+        if (val < 0) return null;
         else {
-            byte[] abyte = new byte[short1];
+            byte[] abyte = new byte[val];
             dat.readBytes(abyte);
             return CompressedStreamTools.func_152457_a(abyte, NBTSizeTracker.field_152451_a);
         }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24655

Look like some entities are a bit too big for a short and get truncated.

> [12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.NBTTagCompound.func_152449_a:407
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.NBTTagCompound.func_152446_a:52
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.NBTTagCompound.func_152449_a:398
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.NBTTagCompound.func_152446_a:52
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.NBTTagCompound.func_152449_a:398
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.NBTTagCompound.func_152446_a:52
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.CompressedStreamTools.func_152455_a:170
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.CompressedStreamTools.func_152456_a:125
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.CompressedStreamTools.func_152457_a:65
[12:08:14] [Client thread/WARN] [Waila]: mcp.mobius.waila.network.WailaPacketHandler.readNBT:108
[12:08:14] [Client thread/WARN] [Waila]: Caused by: java.io.EOFException: Unexpected end of ZLIB input stream
[12:08:14] [Client thread/WARN] [Waila]: java.util.zip.InflaterInputStream.fill:310
[12:08:14] [Client thread/WARN] [Waila]: java.util.zip.InflaterInputStream.read:208
[12:08:14] [Client thread/WARN] [Waila]: java.util.zip.GZIPInputStream.read:151
[12:08:14] [Client thread/WARN] [Waila]: java.io.BufferedInputStream.fill:289
[12:08:14] [Client thread/WARN] [Waila]: java.io.BufferedInputStream.read1:330
[12:08:14] [Client thread/WARN] [Waila]: java.io.BufferedInputStream.read:388
[12:08:14] [Client thread/WARN] [Waila]: java.io.DataInputStream.readFully:213
[12:08:14] [Client thread/WARN] [Waila]: java.io.DataInputStream.readInt:390
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.NBTTagIntArray.func_152446_a:39
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.NBTTagCompound.func_152449_a:398
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.NBTTagCompound.func_152446_a:52
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.NBTTagCompound.func_152449_a:398
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.NBTTagCompound.func_152446_a:52
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.NBTTagCompound.func_152449_a:398
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.NBTTagCompound.func_152446_a:52
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.CompressedStreamTools.func_152455_a:170
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.CompressedStreamTools.func_152456_a:125
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.nbt.CompressedStreamTools.func_152457_a:65
[12:08:14] [Client thread/WARN] [Waila]: mcp.mobius.waila.network.WailaPacketHandler.readNBT:108
[12:08:14] [Client thread/WARN] [Waila]: mcp.mobius.waila.network.Message0x04EntNBTData.decodeInto:29
[12:08:14] [Client thread/WARN] [Waila]: mcp.mobius.waila.network.WailaPacketHandler$WailaCodec.decodeInto:75
[12:08:14] [Client thread/WARN] [Waila]: mcp.mobius.waila.network.WailaPacketHandler$WailaCodec.decodeInto:58
[12:08:14] [Client thread/WARN] [Waila]: cpw.mods.fml.common.network.FMLIndexedMessageToMessageCodec.decode:77
[12:08:14] [Client thread/WARN] [Waila]: cpw.mods.fml.common.network.FMLIndexedMessageToMessageCodec.decode:17
[12:08:14] [Client thread/WARN] [Waila]: io.netty.handler.codec.MessageToMessageCodec$2.decode:81
[12:08:14] [Client thread/WARN] [Waila]: io.netty.handler.codec.MessageToMessageDecoder.channelRead:89
[12:08:14] [Client thread/WARN] [Waila]: io.netty.handler.codec.MessageToMessageCodec.channelRead:111
[12:08:14] [Client thread/WARN] [Waila]: io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead:337
[12:08:14] [Client thread/WARN] [Waila]: io.netty.channel.DefaultChannelHandlerContext.fireChannelRead:323
[12:08:14] [Client thread/WARN] [Waila]: io.netty.channel.DefaultChannelPipeline.fireChannelRead:785
[12:08:14] [Client thread/WARN] [Waila]: io.netty.channel.embedded.EmbeddedChannel.writeInbound:169
[12:08:14] [Client thread/WARN] [Waila]: cpw.mods.fml.common.network.internal.FMLProxyPacket.processPacket:77
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.network.NetworkManager.processReceivedPackets:212
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.client.multiplayer.PlayerControllerMP.updateController:273
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.client.Minecraft.runTick:1602
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.client.Minecraft.runGameLoop:973
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.client.Minecraft.run:9110
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.client.main.Main.main:148
[12:08:14] [Client thread/WARN] [Waila]: jdk.internal.reflect.DirectMethodHandleAccessor.invoke:104
[12:08:14] [Client thread/WARN] [Waila]: java.lang.reflect.Method.invoke:565
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.launchwrapper.Launch.rfb$realLaunch:250
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.launchwrapper.Launch.launch:35
[12:08:14] [Client thread/WARN] [Waila]: net.minecraft.launchwrapper.Launch.main:60
[12:08:14] [Client thread/WARN] [Waila]: jdk.internal.reflect.DirectMethodHandleAccessor.invoke:104
[12:08:14] [Client thread/WARN] [Waila]: java.lang.reflect.Method.invoke:565
[12:08:14] [Client thread/WARN] [Waila]: com.gtnewhorizons.retrofuturabootstrap.Main.main:207
[12:08:14] [Client thread/WARN] [Waila]: com.gtnewhorizons.retrofuturabootstrap.MainStartOnFirstThread.lambda$main$1:47
[12:08:14] [Client thread/WARN] [Waila]: java.lang.Thread.run:1474
[12:08:14] [Client thread/WARN] [Waila]: Catched unhandled exception : [class mcp.mobius.waila.network.Message0x04EntNBTData] net.minecraft.util.ReportedException: Loading NBT data